### PR TITLE
Add fuzzy search for users

### DIFF
--- a/muze/__tests__/db/UserGet.fuzzySearch.test.ts
+++ b/muze/__tests__/db/UserGet.fuzzySearch.test.ts
@@ -8,9 +8,8 @@ jest.mock('@/lib/supabase/supabase', () => ({
   },
 }));
 
-describe('Fuzzy Search for Users', () => {
-  it('should return fuzzy-matched users', async () => {
-    // Simulate returned data from supabase.rpc
+describe('Fuzzy Search for Users - Improved Algorithm', () => {
+  it('should return fuzzy-matched users sorted by relevance score', async () => {
     const fakeUsers = [
       {
         id: '1',
@@ -19,6 +18,7 @@ describe('Fuzzy Search for Users', () => {
         bio: null,
         created_at: '2023-03-01T00:00:00Z',
         email: 'maxine@example.com',
+        relevance_score: 0.9,
       },
       {
         id: '2',
@@ -27,12 +27,17 @@ describe('Fuzzy Search for Users', () => {
         bio: null,
         created_at: '2023-03-02T00:00:00Z',
         email: 'max@example.com',
+        relevance_score: 0.7,
       },
     ];
+    
     (supabase.rpc as jest.Mock).mockResolvedValue({ data: fakeUsers, error: null });
-
+    
     const users = await GetUsersByUsername('Maxin');
     expect(users).toHaveLength(2);
+    // Check that the first user has a higher (or equal) relevance score than the second user.
+    expect(users[0].relevance_score).toBeGreaterThanOrEqual(users[1].relevance_score);
+    // Ensure that at least one username contains 'Max'
     expect(users[0].username).toMatch(/Max/i);
   });
 

--- a/muze/__tests__/db/UserGet.fuzzySearch.test.ts
+++ b/muze/__tests__/db/UserGet.fuzzySearch.test.ts
@@ -1,0 +1,43 @@
+import { GetUsersByUsername } from '@/db/UserGet';
+import { supabase } from '@/lib/supabase/supabase';
+
+// Mock the supabase.rpc method
+jest.mock('@/lib/supabase/supabase', () => ({
+  supabase: {
+    rpc: jest.fn(),
+  },
+}));
+
+describe('Fuzzy Search for Users', () => {
+  it('should return fuzzy-matched users', async () => {
+    // Simulate returned data from supabase.rpc
+    const fakeUsers = [
+      {
+        id: '1',
+        username: 'Maxine',
+        profile_pic: null,
+        bio: null,
+        created_at: '2023-03-01T00:00:00Z',
+        email: 'maxine@example.com',
+      },
+      {
+        id: '2',
+        username: 'Max',
+        profile_pic: null,
+        bio: null,
+        created_at: '2023-03-02T00:00:00Z',
+        email: 'max@example.com',
+      },
+    ];
+    (supabase.rpc as jest.Mock).mockResolvedValue({ data: fakeUsers, error: null });
+
+    const users = await GetUsersByUsername('Maxin');
+    expect(users).toHaveLength(2);
+    expect(users[0].username).toMatch(/Max/i);
+  });
+
+  it('should throw an error when rpc returns an error', async () => {
+    (supabase.rpc as jest.Mock).mockResolvedValue({ data: null, error: { message: 'RPC Error' } });
+    await expect(GetUsersByUsername('Maxin')).rejects.toThrow('RPC Error');
+  });
+});

--- a/muze/package-lock.json
+++ b/muze/package-lock.json
@@ -67,7 +67,6 @@
             "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
             "dev": true,
             "license": "MIT",
-            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -3022,7 +3021,7 @@
             "version": "19.0.3",
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.0.3.tgz",
             "integrity": "sha512-0Knk+HJiMP/qOZgMyNFamlIjw9OFCsyC2ZbigmEEyXXixgre6IQpm/4V+r3qH4GC1JPvRJKInw+on2rV6YZLeA==",
-            "dev": true,
+            "devOptional": true,
             "peerDependencies": {
                 "@types/react": "^19.0.0"
             }
@@ -4198,6 +4197,18 @@
             "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
             "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
             "dev": true
+        },
+        "node_modules/class-variance-authority": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+            "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "clsx": "^2.1.1"
+            },
+            "funding": {
+                "url": "https://polar.sh/cva"
+            }
         },
         "node_modules/client-only": {
             "version": "0.0.1",
@@ -10782,6 +10793,16 @@
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true
         },
+        "node_modules/tailwind-merge": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.0.2.tgz",
+            "integrity": "sha512-l7z+OYZ7mu3DTqrL88RiKrKIqO3NcpEO8V/Od04bNpvk0kiIFndGEoqfuzvj4yuhRkHKjRkII2z+KS2HfPcSxw==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/dcastil"
+            }
+        },
         "node_modules/tailwindcss": {
             "version": "3.4.1",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.1.tgz",
@@ -10846,6 +10867,26 @@
             "dependencies": {
                 "is-glob": "^4.0.1"
             },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/tailwindcss/node_modules/lilconfig": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+            "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/tailwindcss/node_modules/object-hash": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+            "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+            "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 6"
             }

--- a/muze/src/db/UserGet.ts
+++ b/muze/src/db/UserGet.ts
@@ -2,27 +2,27 @@
 import { supabase } from '@/lib/supabase/supabase';
 
 export async function GetUserById(userId: string) {
-    const { data, error } = await supabase
-        .from('users')
-        .select('*')
-        .match({ id: userId })
-        .limit(1)
-        .single();
-    if (error) throw error;
-    return data;
+  const { data, error } = await supabase
+    .from('users')
+    .select('*')
+    .match({ id: userId })
+    .limit(1)
+    .single();
+  if (error) throw error;
+  return data;
 }
 
-// TODO: implement fuzzy searching; will need to use rpc
 export async function GetUsersByUsername(
     username: string,
     limit: number = 50,
     offset: number = 0
-) {
-    const { data, error } = await supabase
-        .from('users')
-        .select('id, username, profile_pic, bio')
-        .match({ username: username })
-        .range(offset, offset + limit - 1);
-    if (error) throw error;
-    return data;
-}
+  ) {
+    const { data, error } = await supabase.rpc('search_users_by_username', { search: username });
+    if (error) {
+      throw new Error(error.message);
+    }
+    
+    // Apply local pagination
+    return data.slice(offset, offset + limit);
+  }
+  

--- a/muze/src/db/UserGet.ts
+++ b/muze/src/db/UserGet.ts
@@ -13,16 +13,14 @@ export async function GetUserById(userId: string) {
 }
 
 export async function GetUsersByUsername(
-    username: string,
-    limit: number = 50,
-    offset: number = 0
-  ) {
-    const { data, error } = await supabase.rpc('search_users_by_username', { search: username });
-    if (error) {
-      throw new Error(error.message);
-    }
-    
-    // Apply local pagination
-    return data.slice(offset, offset + limit);
+  username: string,
+  limit: number = 50,
+  offset: number = 0
+) {
+  const { data, error } = await supabase.rpc('search_users_by_username', { search: username });
+  if (error) {
+    throw new Error(error.message);
   }
   
+  return (data as any[]).slice(offset, offset + limit);
+}

--- a/muze/src/db/database.types.ts
+++ b/muze/src/db/database.types.ts
@@ -241,8 +241,20 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
-      [_ in never]: never
-    }
+      search_users_by_username: {
+        Args: {
+          search: string;
+        },
+        Returns: {
+          id: string;
+          username: string;
+          profile_pic: string | null;
+          bio: string | null;
+          created_at: string | null;
+          email: string;
+        }[];
+      };
+    },
     Enums: {
       [_ in never]: never
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "Muze",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Muze",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
# Description

This PR adds fuzzy search functionality for usernames using PostgreSQL's `pg_trgm` extension. The new RPC function `search_users_by_username` computes a similarity score and returns users whose usernames are sufficiently close to the search term, ordered by relevance.

### Changes:
- **Fuzzy Search Backend:**  (1) Introduces `search_users_by_username` in Supabase to enable similarity-based username searches. (2) Uses `pg_trgm` for trigram-based similarity scoring and filtering.  (3) Limits results to those above a similarity threshold (0.3) and sorts them in descending order.

- **API Integration:** Adds `GetUsersByUsername` in `src/db/UserGet.ts` to call the new RPC function. I've added a `slice` so this supports pagination.

- **Jest Testing:** Adds `__tests__/db/UserGet.fuzzySearch.test.ts` to verify that (1) fuzzy search returns users sorted by relevance score, and (2) the function correctly throws an error when the RPC call fails.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

### **Unit Tests**
- **Valid Search Test:**  This mocks the RPC to return users with different similarity scores. Asserts that results are sorted by highest relevance first.  

- **Error Handling Test:**  Mocks an RPC failure scenario. Asserts that the function throws the expected error.  

# Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
